### PR TITLE
Option to set BitRate when Transcode is set

### DIFF
--- a/MB_SubSonic/Domain/SubsonicSettings.cs
+++ b/MB_SubSonic/Domain/SubsonicSettings.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 
 namespace MusicBeePlugin.Domain
 {
@@ -30,6 +31,7 @@ namespace MusicBeePlugin.Domain
         public bool Transcode { get; set; }
         public ConnectionProtocol Protocol { get; set; }
         public AuthMethod Auth { get; set; }
+        public string BitRate { get; set; }
     }
 
     public static class SubsonicSettingsExtensions


### PR DESCRIPTION
* New option to set BitRate when Transcode option is set
* Default to "Unlimited", will have no impact as server should be limiting as of now
* Removed option to send the format as "mp3" so that all encoders are considered
* Tested on Airsonic